### PR TITLE
[Feat] prisma, swagger, validator, 예시 api 세팅

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tama-server",
+  "name": "dahae-server",
   "version": "0.0.1",
   "description": "",
   "author": "",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,15 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id Int @id @default(autoincrement())
+}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { CommonModule } from '../common/common.module';
+import { UserModule } from '../user/user.module';
 
 @Module({
-  imports: [CommonModule],
+  imports: [CommonModule, UserModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { CommonModule } from '../common/common.module';
 
 @Module({
-  imports: [],
+  imports: [CommonModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { PrismaService } from './services/prisma.service';
+
+@Global()
+@Module({
+  providers: [PrismaService],
+  exports: [PrismaService],
+})
+export class CommonModule {}

--- a/src/common/services/prisma.service.ts
+++ b/src/common/services/prisma.service.ts
@@ -1,0 +1,9 @@
+import { PrismaClient } from '@prisma/client';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class PrismaService extends PrismaClient {
+  constructor() {
+    super();
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app/app.module';
 import { ValidationPipe } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -15,6 +16,18 @@ async function bootstrap() {
       skipUndefinedProperties: true,
     }),
   );
+
+  // swagger 세팅
+  const config = new DocumentBuilder()
+    .setTitle('DaHae Server')
+    .setDescription('DaHae API description')
+    .setVersion('1.0')
+    .addTag('DaHae')
+    .addBearerAuth()
+    .build();
+
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('docs', app, document);
 
   await app.listen(3000);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,21 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app/app.module';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  // class validator 세팅
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      forbidUnknownValues: true,
+      skipUndefinedProperties: true,
+    }),
+  );
+
   await app.listen(3000);
 }
 bootstrap();

--- a/src/user/dto/test.dto.ts
+++ b/src/user/dto/test.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { TestType } from '../types/test.type';
+
+export class TestDto {
+  @ApiProperty({ type: String })
+  a!: string;
+
+  @ApiProperty({ type: String })
+  b!: string;
+
+  @ApiProperty({ type: String })
+  c!: string;
+
+  static of(data: TestType): TestDto {
+    return {
+      a: data.a,
+      b: data.b,
+      c: data.c,
+    };
+  }
+}

--- a/src/user/payload/test.payload.ts
+++ b/src/user/payload/test.payload.ts
@@ -1,0 +1,27 @@
+import { IsDefined, IsOptional, IsString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class TestPayload {
+  // 필수 필드
+  @IsDefined()
+  @IsString()
+  @ApiProperty({ type: String, description: '필수 필드' })
+  a!: string;
+
+  // null 또는 undefined 허용
+  @IsOptional()
+  @IsString()
+  @ApiPropertyOptional({
+    type: String,
+    description: 'null 또는 undefined 허용',
+  })
+  b?: string | null;
+
+  // undefined 허용, null 불가
+  @IsString()
+  @ApiPropertyOptional({
+    type: String,
+    description: 'undefined 허용, null 불가',
+  })
+  c?: string;
+}

--- a/src/user/types/test.type.ts
+++ b/src/user/types/test.type.ts
@@ -1,0 +1,5 @@
+export type TestType = {
+  a: string;
+  b: string;
+  c: string;
+};

--- a/src/user/user.controller.spec.ts
+++ b/src/user/user.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserController } from './user.controller';
+
+describe('UserController', () => {
+  let controller: UserController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UserController],
+    }).compile();
+
+    controller = module.get<UserController>(UserController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,0 +1,19 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { UserService } from './user.service';
+import { TestDto } from './dto/test.dto';
+import { TestPayload } from './payload/test.payload';
+
+@ApiTags('User API')
+@Controller('users')
+export class UserController {
+  constructor(private readonly userService: UserService) {}
+
+  //예시입니다.
+  @Post('test')
+  @ApiOperation({ summary: 'test합니다.' })
+  @ApiOkResponse({ type: TestDto })
+  async test(@Body() payload: TestPayload): Promise<TestDto> {
+    return this.userService.test(payload);
+  }
+}

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { UserService } from './user.service';
+import { UserRepository } from './user.repository';
+import { UserController } from './user.controller';
+
+@Module({
+  providers: [UserService, UserRepository],
+  controllers: [UserController],
+})
+export class UserModule {}

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../common/services/prisma.service';
+
+@Injectable()
+export class UserRepository {
+  constructor(private readonly prisma: PrismaService) {}
+}

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserService } from './user.service';
+
+describe('UserService', () => {
+  let service: UserService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [UserService],
+    }).compile();
+
+    service = module.get<UserService>(UserService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { UserRepository } from './user.repository';
+import { TestPayload } from './payload/test.payload';
+import { TestDto } from './dto/test.dto';
+import { TestType } from './types/test.type';
+
+@Injectable()
+export class UserService {
+  constructor(private readonly userRepository: UserRepository) {}
+
+  async test(payload: TestPayload): Promise<TestDto> {
+    // 필요한 경우 주입받은 userRepository를 사용하여 DB에 접근합니다.
+
+    const data: TestType = {
+      a: payload.a,
+      b: payload.b ?? 'b',
+      c: payload.c ?? 'c',
+    };
+
+    return TestDto.of(data);
+  }
+}


### PR DESCRIPTION
## Type
PR 종류를 확인해 주세요.
- [ ] Improvement
- [X] New feature
- [ ] Bug fix
- [ ] CI/CD, INFRA
- [ ] Etc


## Purpose
- prisma client를 전역으로 사용할 수 있게 세팅했습니다. constructor에 정의해두면 런타임에서 주입되어 사용할 수 있습니다.
- swagger을 세팅했습니다. `http://localhost:3000/docs/` 실행하고 여기로 접속하면 확인 가능합니다.
- global validator를 세팅했습니다. 세팅값마다 validator의 작동 방식이 달라서, 해당 부분(main.ts) 참고해서 validator 사용해주세요. payload 클래스에서 케이스별 사용 예시를 포함해 두었습니다.
- 예시 api를 세팅해두었습니다. service, controller 구조는 동일한데, prisma 쿼리가 쓰다보면 길어지는 편이어서 원래 의미와는 다르지만 repository라는 class를 만들어서 그곳에서 prisma client를 주입받아 사용합니다. service에서 db에 상호작용이 필요할때는 repository를 사용해서 요청합니다.


## Related issue
- resolve #4


## Additional context
- 프로젝트 이름이 DaHae => "다"마고치 "해"빗 트래커 가 된 관계로ㅋㅋ.. 몇가지 이름을 바꿨습니다..ㅋㅋ
- 따로 궁금한 부분 코멘트 달아주셔도 되고, 금요일 중으로 머지할게요!