### PR TITLE
[Schema] 이메일 기반 로그인 관련 스키마 변경

### DIFF
--- a/prisma/migrations/20221126082837_email_based_login/migration.sql
+++ b/prisma/migrations/20221126082837_email_based_login/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `account_id` on the `user` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[email]` on the table `user` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `email` to the `user` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `password` to the `user` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "user" DROP COLUMN "account_id",
+ADD COLUMN     "email" TEXT NOT NULL,
+ADD COLUMN     "password" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_email_key" ON "user"("email");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,7 +16,8 @@ model User {
   createdAt          DateTime  @default(now()) @map("created_at")
   updatedAt          DateTime  @updatedAt @map("updated_at")
   deletedAt          DateTime? @map("deleted_at")
-  accountId          String    @map("account_id")
+  email              String    @unique
+  password           String
   name               String
   role               UserRole  @default(USER)
   photo              String?


### PR DESCRIPTION
## Type
PR 종류를 확인해 주세요.
- [ ] Improvement
- [X] New feature
- [ ] Bug fix
- [ ] CI/CD, INFRA
- [ ] Etc


## Purpose
- email 기반으로 자체 로그인을 구성해야 하므로, 기존의 account_id를 제거하고, email과 pw를 추가합니다.
- email로 특정 유저를 조회해야하므로, email은 unique 제약을 추가했습니다.


## Related issue
- resolve #10 


## Checklist
- @yunz0926 approve 주시면 바로 머지하겠습니다!
