### PR TITLE
[Infra] beanstalk에 바로 배포하도록 dev workflow 수정

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,4 +1,4 @@
-name: Deploy to Amazon ECR
+name: Deploy to Amazon Elastic Beanstalk
 
 on:
   push:
@@ -48,3 +48,14 @@ jobs:
           docker build -f dev.dockerfile -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+      - name: Deploy to EB
+        uses: einaregilsson/beanstalk-deploy@v14
+        with:
+          aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          application_name: dahae-dev
+          environment_name: Dahaedev-env
+          region: ap-northeast-2
+          version_label: ${{github.SHA}}
+          deployment_package: Dockerrun.aws.json

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -1,0 +1,13 @@
+{
+  "AWSEBDockerrunVersion": "1",
+    "Image": {
+        "Name": "257201867894.dkr.ecr.ap-northeast-2.amazonaws.com/dahae-dev-repo:latest",
+        "Update": "true"
+    },
+    "Ports": [
+        {
+            "ContainerPort": "3000",
+            "HostPort": "80"
+        }
+    ]
+}

--- a/src/app/app.service.ts
+++ b/src/app/app.service.ts
@@ -3,6 +3,6 @@ import { Injectable } from '@nestjs/common';
 @Injectable()
 export class AppService {
   getHello(): string {
-    return 'Hello Dahae!';
+    return 'Hello DahaeDev!';
   }
 }


### PR DESCRIPTION
## Type
PR 종류를 확인해 주세요.
- [ ] Improvement
- [ ] New feature
- [ ] Bug fix
- [X] CI/CD, INFRA
- [ ] Etc


## Purpose
- 기존에는 ECR에 이미지를 올린 후, aws lambda로 beanstalk을 재시작하려했는데, 바로 여기서 beanstalk에 Dockerrun.aws.json을 배포하는 방식으로 배포가 가능할 것으로 보여서 수정합니다.


## Related issue
- #23 


## Checklist
- 제발 되라..ㅠ
