### PR TITLE
[Feat] default user interceptor 추가

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -9,7 +9,6 @@ import { AuthService } from './auth.service';
 import { CreateUserPayload } from './payload/create.user.payload';
 import { LoginUserPayload } from './payload/login.user.payload';
 import { CreateUserDto } from './dto/create.user.dto';
-import { boolean } from 'joi';
 
 @ApiTags('Auth API')
 @Controller('auth')

--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -1,9 +1,10 @@
 import { Global, Module } from '@nestjs/common';
+import { DefaultUserInterceptor } from './interceptor/default.user.interceptor';
 import { PrismaService } from './services/prisma.service';
 
 @Global()
 @Module({
-  providers: [PrismaService],
-  exports: [PrismaService],
+  providers: [PrismaService, DefaultUserInterceptor],
+  exports: [PrismaService, DefaultUserInterceptor],
 })
 export class CommonModule {}

--- a/src/common/interceptor/default.user.interceptor.ts
+++ b/src/common/interceptor/default.user.interceptor.ts
@@ -1,0 +1,39 @@
+import { UserInfoType } from './../../user/types/userInfo.type';
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { PrismaService } from '../services/prisma.service';
+
+@Injectable()
+export class DefaultUserInterceptor implements NestInterceptor {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Promise<Observable<any>> {
+    const request = context.switchToHttp().getRequest();
+    const { user } = request;
+
+    if (!user) {
+      const defaultUser = await this.prisma.user.findFirst({});
+      request.user = {
+        id: defaultUser.id,
+        createdAt: defaultUser.createdAt,
+        email: defaultUser.email,
+        name: defaultUser.name,
+        role: defaultUser.role,
+        photo: defaultUser.photo,
+        os: defaultUser.os,
+        streak: defaultUser.streak,
+        marketingAgreement: defaultUser.marketingAgreement,
+      } as UserInfoType;
+    }
+
+    return next.handle();
+  }
+}

--- a/src/habit/habit.controller.ts
+++ b/src/habit/habit.controller.ts
@@ -4,7 +4,6 @@ import {
   Get,
   Post,
   Req,
-  UseGuards,
   Query,
   Put,
   Delete,
@@ -14,14 +13,12 @@ import {
 } from '@nestjs/common';
 import { HabitService } from './habit.service';
 import {
-  ApiBearerAuth,
   ApiCreatedResponse,
   ApiOperation,
   ApiTags,
   ApiParam,
 } from '@nestjs/swagger';
 import { CreateHabitPayload } from './payload/create.habit.payload';
-import { JwtAuthGuard } from '../auth/guard/jwt-auth.guard';
 import { CurrentUser } from 'src/auth/decorator/user.decorator';
 import { UserInfoType } from 'src/user/types/userInfo.type';
 import { ChangeProgressPayload } from './payload/change.progress.payload';
@@ -35,9 +32,7 @@ import { UpdateHabitPayload } from './payload/update.habit.payload';
 export class HabitController {
   constructor(private readonly habitService: HabitService) {}
 
-  @ApiBearerAuth()
   @Post('/')
-  @UseGuards(JwtAuthGuard)
   @ApiOperation({ summary: 'create habit' })
   async createHabit(
     @Req() req,
@@ -48,9 +43,7 @@ export class HabitController {
     return this.habitService.createHabit(id, createHabitPayload);
   }
 
-  @ApiBearerAuth()
   @Get('/')
-  @UseGuards(JwtAuthGuard)
   @ApiOperation({ summary: 'get habit list' })
   @ApiCreatedResponse({
     type: GetHabitListDto,
@@ -62,9 +55,7 @@ export class HabitController {
     return this.habitService.getHabitList(id);
   }
 
-  @ApiBearerAuth()
   @Get('/record')
-  @UseGuards(JwtAuthGuard)
   @ApiOperation({ summary: 'get habit records' })
   @ApiCreatedResponse({
     type: GetHabitRecordListDto,
@@ -77,9 +68,7 @@ export class HabitController {
     return this.habitService.getHabitRecords(id, query);
   }
 
-  @ApiBearerAuth()
   @Put('/')
-  @UseGuards(JwtAuthGuard)
   @ApiOperation({ summary: 'change habit progress' })
   async changeProgress(
     @Body() changeProgressPayload: ChangeProgressPayload,
@@ -87,9 +76,7 @@ export class HabitController {
     return this.habitService.changeProgress(changeProgressPayload);
   }
 
-  @ApiBearerAuth()
   @Delete('/:id')
-  @UseGuards(JwtAuthGuard)
   @ApiOperation({ summary: 'delete habit' })
   @ApiParam({
     name: 'id',
@@ -101,9 +88,7 @@ export class HabitController {
     return this.habitService.deleteHabit(id);
   }
 
-  @ApiBearerAuth()
   @Patch('/:id')
-  @UseGuards(JwtAuthGuard)
   @ApiOperation({ summary: 'update habit' })
   async updateHabit(
     @CurrentUser() user: UserInfoType,

--- a/src/habit/habit.controller.ts
+++ b/src/habit/habit.controller.ts
@@ -1,3 +1,4 @@
+import { DefaultUserInterceptor } from '../common/interceptor/default.user.interceptor';
 import {
   Body,
   Controller,
@@ -10,6 +11,7 @@ import {
   Param,
   Patch,
   ParseIntPipe,
+  UseInterceptors,
 } from '@nestjs/common';
 import { HabitService } from './habit.service';
 import {
@@ -33,17 +35,17 @@ export class HabitController {
   constructor(private readonly habitService: HabitService) {}
 
   @Post('/')
+  @UseInterceptors(DefaultUserInterceptor)
   @ApiOperation({ summary: 'create habit' })
   async createHabit(
-    @Req() req,
-    @Body()
-    createHabitPayload: CreateHabitPayload,
+    @CurrentUser() user: UserInfoType,
+    @Body() createHabitPayload: CreateHabitPayload,
   ): Promise<void> {
-    const { id } = req.user;
-    return this.habitService.createHabit(id, createHabitPayload);
+    return this.habitService.createHabit(user.id, createHabitPayload);
   }
 
   @Get('/')
+  @UseInterceptors(DefaultUserInterceptor)
   @ApiOperation({ summary: 'get habit list' })
   @ApiCreatedResponse({
     type: GetHabitListDto,
@@ -92,8 +94,7 @@ export class HabitController {
   @ApiOperation({ summary: 'update habit' })
   async updateHabit(
     @CurrentUser() user: UserInfoType,
-    @Body()
-    updateHabitPayload: UpdateHabitPayload,
+    @Body() updateHabitPayload: UpdateHabitPayload,
     @Param('id', ParseIntPipe) habitId: number,
   ): Promise<void> {
     const userId = user.id;

--- a/src/habit/habit.controller.ts
+++ b/src/habit/habit.controller.ts
@@ -53,11 +53,11 @@ export class HabitController {
   async getHabitList(
     @CurrentUser() user: UserInfoType,
   ): Promise<GetHabitListDto> {
-    const { id } = user;
-    return this.habitService.getHabitList(id);
+    return this.habitService.getHabitList(user.id);
   }
 
   @Get('/record')
+  @UseInterceptors(DefaultUserInterceptor)
   @ApiOperation({ summary: 'get habit records' })
   @ApiCreatedResponse({
     type: GetHabitRecordListDto,
@@ -66,8 +66,7 @@ export class HabitController {
     @CurrentUser() user: UserInfoType,
     @Query() query: GetHabitRecordPayload,
   ): Promise<GetHabitRecordListDto> {
-    const { id } = user;
-    return this.habitService.getHabitRecords(id, query);
+    return this.habitService.getHabitRecords(user.id, query);
   }
 
   @Put('/')
@@ -76,6 +75,18 @@ export class HabitController {
     @Body() changeProgressPayload: ChangeProgressPayload,
   ): Promise<void> {
     return this.habitService.changeProgress(changeProgressPayload);
+  }
+
+  @Patch('/:id')
+  @UseInterceptors(DefaultUserInterceptor)
+  @ApiOperation({ summary: 'update habit' })
+  async updateHabit(
+    @CurrentUser() user: UserInfoType,
+    @Body() updateHabitPayload: UpdateHabitPayload,
+    @Param('id', ParseIntPipe) habitId: number,
+  ): Promise<void> {
+    const userId = user.id;
+    return this.habitService.updateHabit(userId, habitId, updateHabitPayload);
   }
 
   @Delete('/:id')
@@ -88,16 +99,5 @@ export class HabitController {
   })
   async deleteHabit(@Param('id', ParseIntPipe) id: number): Promise<void> {
     return this.habitService.deleteHabit(id);
-  }
-
-  @Patch('/:id')
-  @ApiOperation({ summary: 'update habit' })
-  async updateHabit(
-    @CurrentUser() user: UserInfoType,
-    @Body() updateHabitPayload: UpdateHabitPayload,
-    @Param('id', ParseIntPipe) habitId: number,
-  ): Promise<void> {
-    const userId = user.id;
-    return this.habitService.updateHabit(userId, habitId, updateHabitPayload);
   }
 }

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -9,7 +9,7 @@ export class UserRepository {
   async create(createUserPayload: CreateUserPayload): Promise<User> {
     const { email, password, name, os } = createUserPayload;
 
-    return await this.prisma.user.create({
+    return this.prisma.user.create({
       data: {
         email,
         password,
@@ -34,7 +34,7 @@ export class UserRepository {
   }
 
   async getUserByEmail(email: string): Promise<User> {
-    return await this.prisma.user.findUnique({
+    return this.prisma.user.findUnique({
       where: {
         email,
       },
@@ -42,7 +42,7 @@ export class UserRepository {
   }
 
   async getUserByName(name: string): Promise<User> {
-    return await this.prisma.user.findFirst({
+    return this.prisma.user.findFirst({
       where: {
         name,
       },
@@ -50,11 +50,15 @@ export class UserRepository {
   }
 
   async getUserById(id: string): Promise<User> {
-    return await this.prisma.user.findFirst({
+    return this.prisma.user.findFirst({
       where: {
         id,
         deletedAt: null,
       },
     });
+  }
+
+  async getDefaultUser(): Promise<User> {
+    return this.prisma.user.findFirst({});
   }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -35,4 +35,19 @@ export class UserService {
       marketingAgreement: user.marketingAgreement,
     };
   }
+
+  async getDefaultUser(): Promise<UserInfoType> {
+    const user = await this.userRepository.getDefaultUser();
+    return {
+      id: user.id,
+      createdAt: user.createdAt,
+      email: user.email,
+      name: user.name,
+      role: user.role,
+      photo: user.photo,
+      os: user.os,
+      streak: user.streak,
+      marketingAgreement: user.marketingAgreement,
+    };
+  }
 }


### PR DESCRIPTION
## Type
PR 종류를 확인해 주세요.
- [ ] Improvement
- [X] New feature
- [ ] Bug fix
- [ ] CI/CD, INFRA
- [ ] Etc


## Purpose
- 기존에 bearer token을 필요로 하던 api들에서 관련 데코레이터를 제거하였습니다.
- 대신, findFirst로 맨 위에 미리 등록된 유저를 가져와서 해당 정보를 대신 반환하는 interceptor를 작성했습니다.
- 따라서 모든 요청은 특정 유저라고 가정하고 처리됩니다.


## Related issue
- resolve #33 
