### PR TITLE
[Refactor] habit 모듈에서 prisma 의존성 제거

### DIFF
--- a/src/habit/dto/habit.dto.ts
+++ b/src/habit/dto/habit.dto.ts
@@ -64,4 +64,10 @@ export class HabitDto {
 export class HabitListDto {
   @ApiProperty({ type: [HabitDto] })
   habits: HabitDto[];
+
+  static of(habits: HabitData[]): HabitListDto {
+    return {
+      habits: habits.map((habit) => HabitDto.of(habit)),
+    };
+  }
 }

--- a/src/habit/dto/habit.dto.ts
+++ b/src/habit/dto/habit.dto.ts
@@ -1,9 +1,7 @@
+import { HabitData } from './../type/habit.data.type';
 import { ApiProperty } from '@nestjs/swagger';
-import { Habit, HabitRecordDay } from '@prisma/client';
-import {
-  convertHabitTimeToString,
-  convertDayBitToString,
-} from 'src/utils/date';
+import { HabitRecordDay } from '@prisma/client';
+import { convertHabitTimeToString } from 'src/utils/date';
 
 export class HabitDto {
   @ApiProperty({ type: Number, description: '습관 Id' })
@@ -48,7 +46,7 @@ export class HabitDto {
   })
   days!: HabitRecordDay[];
 
-  static of(habit: Habit): HabitDto {
+  static of(habit: HabitData): HabitDto {
     return {
       id: habit.id,
       title: habit.title,
@@ -58,7 +56,7 @@ export class HabitDto {
       time: convertHabitTimeToString(habit.time),
       startDate: habit.startDate,
       endDate: habit.endDate,
-      days: convertDayBitToString(habit.days),
+      days: habit.days,
     };
   }
 }

--- a/src/habit/dto/habit.record.dto.ts
+++ b/src/habit/dto/habit.record.dto.ts
@@ -1,7 +1,6 @@
+import { HabitWithRecordData } from './../type/habit.with.records.type';
 import { ApiProperty } from '@nestjs/swagger';
-import { HabitRecordDay } from '@prisma/client';
 import { convertHabitTimeToString } from 'src/utils/date';
-import { HabitWithRecordsT } from '../type/habit.with.records.type';
 import { HabitDto } from './habit.dto';
 
 export class HabitRecordDto {
@@ -20,7 +19,8 @@ export class HabitRecordDto {
   })
   accomplished!: boolean;
 
-  static of(habit: HabitWithRecordsT): HabitRecordDto {
+  static of(habitRecord: HabitWithRecordData): HabitRecordDto {
+    const habit = habitRecord.habit;
     return {
       habit: {
         id: habit.id,
@@ -31,28 +31,10 @@ export class HabitRecordDto {
         startDate: habit.startDate,
         endDate: habit.endDate,
         time: convertHabitTimeToString(habit.time),
-        days: [habit.habitRecords[0].day],
+        days: habit.days,
       },
-      progress: habit.habitRecords[0].progress,
-      accomplished: habit.habitRecords[0].accomplished,
-    };
-  }
-
-  static ofHabit(habit: HabitDto, day: HabitRecordDay): HabitRecordDto {
-    return {
-      habit: {
-        id: habit.id,
-        title: habit.title,
-        action: habit.action,
-        value: habit.value,
-        unit: habit.unit,
-        startDate: habit.startDate,
-        endDate: habit.endDate,
-        time: habit.time,
-        days: [day],
-      },
-      progress: 0,
-      accomplished: false,
+      progress: habitRecord.progress,
+      accomplished: habitRecord.accomplished,
     };
   }
 }
@@ -60,4 +42,12 @@ export class HabitRecordDto {
 export class HabitRecordListDto {
   @ApiProperty({ type: [HabitRecordDto] })
   habitRecords: HabitRecordDto[];
+
+  static of(habitRecords: HabitWithRecordData[]): HabitRecordListDto {
+    return {
+      habitRecords: habitRecords.map((habitRecord) =>
+        HabitRecordDto.of(habitRecord),
+      ),
+    };
+  }
 }

--- a/src/habit/habit.repository.ts
+++ b/src/habit/habit.repository.ts
@@ -13,7 +13,10 @@ import { UpdateHabitPayload } from './payload/update.habit.payload';
 export class HabitRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  create(userId: string, payload: CreateHabitPayload): Promise<Habit> {
+  async create(
+    userId: string,
+    payload: CreateHabitPayload,
+  ): Promise<HabitData> {
     const { title, action, unit, value, time, startDate, endDate, days } =
       payload;
 
@@ -28,7 +31,7 @@ export class HabitRepository {
       habitTime.setUTCHours(+hh, +mm, 0, 0);
     }
 
-    return this.prisma.habit.create({
+    const habit = await this.prisma.habit.create({
       data: {
         userId,
         title,
@@ -41,6 +44,8 @@ export class HabitRepository {
         days: dayBit,
       },
     });
+
+    return this.toHabitData(habit);
   }
 
   async getHabits(userId: string): Promise<HabitData[]> {

--- a/src/habit/type/habit.data.type.ts
+++ b/src/habit/type/habit.data.type.ts
@@ -1,0 +1,14 @@
+import { HabitRecordDay } from '@prisma/client';
+
+export type HabitData = {
+  id: number;
+  title: string;
+  action: string;
+  value: number;
+  unit: string;
+  time: Date | null;
+  startDate: Date;
+  endDate: Date | null;
+  days: HabitRecordDay[];
+  isActive: boolean;
+};

--- a/src/habit/type/habit.with.records.type.ts
+++ b/src/habit/type/habit.with.records.type.ts
@@ -2,7 +2,7 @@ import { HabitRecordDay } from '@prisma/client';
 import { HabitData } from './habit.data.type';
 
 export type HabitWithRecordData = {
-  id: number;
+  id?: number;
   progress: number;
   accomplished: boolean;
   day: HabitRecordDay;

--- a/src/habit/type/habit.with.records.type.ts
+++ b/src/habit/type/habit.with.records.type.ts
@@ -1,7 +1,11 @@
-import { Prisma } from '@prisma/client';
+import { HabitRecordDay } from '@prisma/client';
+import { HabitData } from './habit.data.type';
 
-export type HabitWithRecordsT = Prisma.HabitGetPayload<{
-  include: {
-    habitRecords: true;
-  };
-}>;
+export type HabitWithRecordData = {
+  id: number;
+  progress: number;
+  accomplished: boolean;
+  day: HabitRecordDay;
+  date: Date;
+  habit: HabitData;
+};


### PR DESCRIPTION
## Type
PR 종류를 확인해 주세요.
- [X] Improvement
- [ ] New feature
- [ ] Bug fix
- [ ] CI/CD, INFRA
- [ ] Etc


## Purpose
- prisma 관련한 타입은 최대한 repository 내에서만 사용하도록 변경합니다.
- layer간 데이터 교환은 별도의 타입을 생성해서 그 형태로 교환합니다.


## Why
- prisma에서 생성해준 타입을 지나치게 여기저기에서 사용할 경우 로직이 db 구조에 의존하게 됩니다.


## Related issue
- resolve #37


## Additional context
- Dto의 static of 메소드에서도 Habit, HabitRecordT를 제거하면서, ofHabit메소드도 제거하는 방식으로 코드를 약간 개선했습니다.